### PR TITLE
KExpFam: fix sign of beta-related stuff

### DIFF
--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamily.cpp
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamily.cpp
@@ -103,6 +103,13 @@ SGMatrix<float64_t> CKernelExpFamily::hessian(index_t i)
 	return m_impl->hessian(i);
 }
 
+SGVector<float64_t> CKernelExpFamily::hessian_diag(index_t i)
+{
+	auto N = m_impl->get_num_data();
+	REQUIRE(i>=0 && i<N, "Given test data index (%d) must be in [0, %d].\n", i, N-1);
+	return m_impl->hessian_diag(i);
+}
+
 float64_t CKernelExpFamily::score()
 {
 	return m_impl->score();

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamily.h
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamily.h
@@ -55,6 +55,7 @@ public:
 	virtual float64_t log_pdf(index_t i=0);
 	virtual SGVector<float64_t> grad(index_t i=0);
 	virtual SGMatrix<float64_t> hessian(index_t i=0);
+	virtual SGVector<float64_t> hessian_diag(index_t i=0);
 
 	virtual SGVector<float64_t> log_pdf_multiple();
 	virtual SGMatrix<float64_t> grad_multiple();

--- a/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
@@ -210,7 +210,7 @@ float64_t Nystrom::log_pdf(index_t idx_test) const
 	{
 		auto grad_x_xa = m_kernel->dx(idx_a, idx_test);
 		Map<VectorXd> eigen_grad_xa(grad_x_xa.vector, D);
-		beta_sum -= eigen_grad_xa.dot(eigen_beta.segment(idx_a*D, D));
+		beta_sum += eigen_grad_xa.dot(eigen_beta.segment(idx_a*D, D));
 	}
 
 	return beta_sum;
@@ -259,7 +259,7 @@ SGVector<float64_t> Nystrom::hessian_diag(index_t idx_test) const
 		SGVector<float64_t> beta_a(eigen_beta.segment(a*D, D).data(), D, false);
 		for (auto i=0; i<D; i++)
 		{
-			eigen_beta_sum_hessian_diag[i] -= m_kernel->dx_i_dx_j_dx_k_dot_vec_component(
+			eigen_beta_sum_hessian_diag[i] += m_kernel->dx_i_dx_j_dx_k_dot_vec_component(
 					a, idx_test, beta_a, i, i);
 		}
 	}


### PR DESCRIPTION
The Nystrom score bugs were related to the sign of beta. I switched the semantics of beta to be the coefficients within the basis (instead of the negative of the coefficients), and added the negative to the fit.

Aapo score for Nystrom now matches the true score as much as the full score does.

Didn't update any tests, so they probably all fail, but I verified that it's correct here: https://gist.github.com/dougalsutherland/fbd7e71bcd19144cf60384b705b85537