### PR TITLE
implement lite basis

### DIFF
--- a/src/interfaces/swig/Distribution.i
+++ b/src/interfaces/swig/Distribution.i
@@ -26,6 +26,7 @@
 %rename(KernelDensity) CKernelDensity;
 %rename(KernelExpFamily) CKernelExpFamily;
 %rename(KernelExpFamilyNystrom) CKernelExpFamilyNystrom;
+%rename(KernelExpFamilyLite) CKernelExpFamilyLite;
 
 
 /* Include Class Headers to make them visible from within the target language */
@@ -41,3 +42,4 @@
 %include <shogun/distributions/classical/GaussianDistribution.h>
 %include <shogun/distributions/kernel_exp_family/KernelExpFamily.h>
 %include <shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.h>
+%include <shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h>

--- a/src/interfaces/swig/Distribution_includes.i
+++ b/src/interfaces/swig/Distribution_includes.i
@@ -11,4 +11,5 @@
 #include <shogun/distributions/classical/GaussianDistribution.h>
 #include <shogun/distributions/kernel_exp_family/KernelExpFamily.h>
 #include <shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.h>
+#include <shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h>
 %}

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2016 Heiko Strathmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/io/SGIO.h>
+#include <shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h>
+#include <shogun/distributions/kernel_exp_family/impl/Lite.h>
+#include <shogun/distributions/kernel_exp_family/impl/NystromD.h>
+#include <memory>
+
+#include "impl/kernel/Gaussian.h"
+
+
+using namespace shogun;
+
+CKernelExpFamilyLite::CKernelExpFamilyLite() : CKernelExpFamily()
+{
+	m_impl=NULL;
+}
+
+CKernelExpFamilyLite::CKernelExpFamilyLite(SGMatrix<float64_t> data,
+			SGMatrix<float64_t> basis,
+			float64_t sigma, float64_t lambda, float64_t lambda_l2)
+			: CKernelExpFamily()
+{
+	REQUIRE(data.matrix, "Given observations cannot be empty.\n");
+	REQUIRE(data.num_rows>0, "Dimension of given observations (%d) must be positive.\n", data.num_rows);
+	REQUIRE(data.num_cols>0, "Number of given observations (%d) must be positive.\n", data.num_cols);
+	REQUIRE(basis.matrix, "Given basis cannot be empty.\n");
+	REQUIRE(basis.num_rows>0, "Dimension of given basis (%d) must be positive.\n", basis.num_rows);
+	REQUIRE(basis.num_cols>0, "Number of given basis (%d) must be positive.\n", basis.num_cols);
+	REQUIRE(sigma>0, "Given sigma (%f) must be positive.\n", sigma);
+	REQUIRE(lambda>0, "Given lambda (%f) must be positive.\n", lambda);
+	REQUIRE(lambda>=0, "Given L2 lambda (%f) must be >=0.\n", lambda_l2);
+
+	auto kernel = std::make_shared<kernel_exp_family_impl::kernel::Gaussian>(sigma);
+	m_impl = new kernel_exp_family_impl::Lite(data, basis, kernel, lambda, lambda_l2);
+}
+
+CKernelExpFamilyLite::CKernelExpFamilyLite(SGMatrix<float64_t> data, index_t num_subsample_basis,
+				float64_t sigma, float64_t lambda, float64_t lambda_l2)
+{
+	REQUIRE(data.matrix, "Given observations cannot be empty.\n");
+	REQUIRE(data.num_rows>0, "Dimension of given observations (%d) must be positive.\n", data.num_rows);
+	REQUIRE(data.num_cols>0, "Number of given observations (%d) must be positive.\n", data.num_cols);
+	REQUIRE(num_subsample_basis>0, "Number of subsampled basis (%d) must be positive.\n", num_subsample_basis);
+	REQUIRE(num_subsample_basis<=data.num_cols, "Number of subsampled basis (%d) must not exceed number of data (%d).\n",
+			num_subsample_basis, data.num_cols);
+	REQUIRE(sigma>0, "Given sigma (%f) must be positive.\n", sigma);
+	REQUIRE(lambda>0, "Given lambda (%f) must be positive.\n", lambda);
+	REQUIRE(lambda>=0, "Given L2 lambda (%f) must be >=0.\n", lambda_l2);
+
+	auto kernel = std::make_shared<kernel_exp_family_impl::kernel::Gaussian>(sigma);
+	m_impl = new kernel_exp_family_impl::Lite(data, num_subsample_basis,
+													kernel, lambda, lambda_l2);
+}
+
+CKernelExpFamilyLite::~CKernelExpFamilyLite()
+{
+	delete m_impl;
+	m_impl=NULL;
+}
+
+void CKernelExpFamilyLite::fit()
+{
+	m_impl->fit();
+}

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2016 Heiko Strathmann
+ * Written (w) 2018 Dougal Sutherland
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.cpp
@@ -94,3 +94,16 @@ void CKernelExpFamilyLite::fit()
 {
 	m_impl->fit();
 }
+
+SGVector<index_t> CKernelExpFamilyLite::get_basis_inds() const
+{
+	return static_cast<kernel_exp_family_impl::Lite *>(m_impl)->get_basis_inds();
+}
+
+SGMatrix<float64_t> CKernelExpFamilyLite::get_matrix(const char* name)
+{
+	if (!strcmp(name, "basis"))
+		return static_cast<kernel_exp_family_impl::Lite *>(m_impl)->get_basis();
+	else
+		return CKernelExpFamily::get_matrix(name);
+}

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2016 Heiko Strathmann
+ * Written (w) 2018 Dougal Sutherland
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2016 Heiko Strathmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#ifndef KERNEL_EXP_FAMILY_LITE__
+#define KERNEL_EXP_FAMILY_LITE__
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/common.h>
+#include <shogun/base/SGObject.h>
+#include <shogun/distributions/kernel_exp_family/KernelExpFamily.h>
+
+namespace shogun
+{
+
+class CKernelExpFamilyLite : public CKernelExpFamily
+{
+public :
+	CKernelExpFamilyLite();
+	CKernelExpFamilyLite(SGMatrix<float64_t> data, SGMatrix<float64_t> basis,
+				float64_t sigma, float64_t lambda, float64_t lambda_l2=0.0);
+
+	CKernelExpFamilyLite(SGMatrix<float64_t> data, index_t num_subsample_basis,
+				float64_t sigma, float64_t lambda, float64_t lambda_l2=0.0);
+
+	virtual void fit();
+
+	virtual ~CKernelExpFamilyLite();
+
+	virtual const char* get_name() const { return "KernelExpFamilyLite"; }
+
+};
+
+}
+#endif // KERNEL_EXP_FAMILY_LITE__

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyLite.h
@@ -55,6 +55,8 @@ public :
 
 	virtual const char* get_name() const { return "KernelExpFamilyLite"; }
 
+    virtual SGVector<index_t> get_basis_inds() const;
+    virtual SGMatrix<float64_t> get_matrix(const char* name="");
 };
 
 }

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.cpp
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.cpp
@@ -139,3 +139,17 @@ CKernelExpFamilyNystrom::CKernelExpFamilyNystrom(SGMatrix<float64_t> data,
 	m_impl = new kernel_exp_family_impl::NystromD(data, basis_mask,
 			kernel, lambda, lambda_l2);
 }
+
+
+SGVector<index_t> CKernelExpFamilyNystrom::get_basis_inds() const
+{
+	return static_cast<kernel_exp_family_impl::Nystrom *>(m_impl)->get_basis_inds();
+}
+
+SGMatrix<float64_t> CKernelExpFamilyNystrom::get_matrix(const char* name)
+{
+	if (!strcmp(name, "basis"))
+		return static_cast<kernel_exp_family_impl::Nystrom *>(m_impl)->get_basis();
+	else
+		return CKernelExpFamily::get_matrix(name);
+}

--- a/src/shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.h
+++ b/src/shogun/distributions/kernel_exp_family/KernelExpFamilyNystrom.h
@@ -62,6 +62,8 @@ public :
 
 	virtual const char* get_name() const { return "KernelExpFamilyNystrom"; }
 
+    virtual SGVector<index_t> get_basis_inds() const;
+    virtual SGMatrix<float64_t> get_matrix(const char* name="");
 };
 
 }

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2016 Heiko Strathmann
+ * Written (w) 2018 Dougal Sutherland
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) The Shogun Machine Learning Toolbox
+ * Written (w) 2016 Heiko Strathmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those
+ * of the authors and should not be interpreted as representing official policies,
+ * either expressed or implied, of the Shogun Development Team.
+ */
+
+#include <shogun/lib/config.h>
+#include <shogun/lib/SGMatrix.h>
+#include <shogun/lib/SGVector.h>
+#include <shogun/mathematics/eigen3.h>
+#include <shogun/mathematics/Math.h>
+#include <memory>
+
+#include "kernel/Base.h"
+#include "Lite.h"
+#include "Nystrom.h"
+#include "Full.h"
+
+using namespace shogun;
+using namespace shogun::kernel_exp_family_impl;
+using namespace Eigen;
+
+Lite::Lite(SGMatrix<float64_t> data, SGMatrix<float64_t> basis,
+		std::shared_ptr<kernel::Base> kernel, float64_t lambda,
+		float64_t lambda_l2, bool init_base_and_data)
+		: Nystrom(data, basis, kernel, lambda, lambda_l2, init_base_and_data)
+{ }
+
+Lite::Lite(SGMatrix<float64_t> data, SGVector<index_t> basis_inds,
+		std::shared_ptr<kernel::Base> kernel, float64_t lambda,
+			float64_t lambda_l2, bool init_base_and_data)
+		: Nystrom(data, basis_inds, kernel, lambda, lambda_l2, init_base_and_data)
+{ }
+
+Lite::Lite(SGMatrix<float64_t> data, index_t num_subsample_basis,
+		std::shared_ptr<kernel::Base> kernel, float64_t lambda,
+			float64_t lambda_l2, bool init_base_and_data)
+		: Nystrom(data, num_subsample_basis, kernel, lambda, lambda_l2, init_base_and_data)
+{ }
+
+index_t Lite::get_system_size() const
+{
+	return get_num_basis();
+}
+
+SGMatrix<float64_t> Lite::subsample_G_mm_from_G_mn(const SGMatrix<float64_t>& G_mn) const
+{
+	// TODO: would be better to make this a compile-time error
+	// like https://stackoverflow.com/a/24610165/344821
+	SG_SERROR("Can't subsample G_mm from G_mn for Lite");
+
+	SGMatrix<float64_t> return_something(0, 0);
+	return return_something;
+}
+bool Lite::can_subsample_G_mm_from_G_mn() const
+{
+	return false;
+}
+
+
+SGMatrix<float64_t> Lite::compute_G_mn() const
+{
+	auto G_mn = m_kernel->dy_all();
+	return G_mn;
+}
+
+SGMatrix<float64_t> Lite::compute_G_mm() const
+{
+	auto basis = m_basis;
+	auto data = m_data;
+
+	auto kernel=m_kernel->shallow_copy();
+	kernel->set_lhs(basis);
+	kernel->set_rhs(basis);
+	kernel->precompute();
+
+	auto G_mm = kernel->kernel_all();
+	return G_mm;
+}
+
+SGVector<float64_t> Lite::compute_h() const
+{
+	auto D = get_num_dimensions();
+	auto N_basis = get_num_basis();
+	auto N_data = get_num_data();
+
+	auto system_size = N_basis;
+	SGVector<float64_t> h(system_size);
+	Map<VectorXd> eigen_h(h.vector, system_size);
+	eigen_h = VectorXd::Zero(system_size);
+
+#pragma omp parallel for
+	for (auto idx_a=0; idx_a<N_basis; idx_a++)
+		for (auto idx_b=0; idx_b<N_data; idx_b++)
+		{
+			// TODO optimise, no need to store matrix
+			// TODO optimise, pull allocation out of the loop
+			SGMatrix<float64_t> temp = m_kernel->dy_dy(idx_a, idx_b);
+			eigen_h.segment(idx_a*D, D) += Map<MatrixXd>(temp.matrix, D,D).colwise().sum();
+		}
+
+	eigen_h /= N_data;
+
+	return h;
+}

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
@@ -127,3 +127,16 @@ SGVector<float64_t> Lite::compute_h() const
 
 	return h;
 }
+
+
+float64_t Lite::log_pdf(index_t idx_test) const
+{
+	auto N_basis = get_num_basis();
+
+	float64_t beta_sum = 0;
+	for (auto idx = 0; idx < N_basis; ++idx)
+	{
+		beta_sum += m_beta[idx] * m_kernel->kernel(idx, idx_test);
+	}
+	return beta_sum;
+}

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) The Shogun Machine Learning Toolbox
- * Written (w) 2016 Heiko Strathmann
+ * Written (w) 2018 Dougal Sutherland
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.h
@@ -72,6 +72,8 @@ public :
 	virtual SGMatrix<float64_t> compute_G_mm() const;
 	virtual SGVector<float64_t> compute_h() const;
 
+	virtual float64_t log_pdf(index_t idx_test) const;
+
 protected:
 
 	float64_t m_lambda_l2;

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.h
@@ -28,8 +28,8 @@
  * either expressed or implied, of the Shogun Development Team.
  */
 
-#ifndef KERNEL_EXP_FAMILY_IMPL_NYSTROM__
-#define KERNEL_EXP_FAMILY_IMPL_NYSTROM__
+#ifndef KERNEL_EXP_FAMILY_IMPL_LITE__
+#define KERNEL_EXP_FAMILY_IMPL_LITE__
 
 #include <shogun/lib/config.h>
 #include <shogun/lib/common.h>
@@ -40,79 +40,38 @@
 
 #include "Base.h"
 #include "Full.h"
+#include "Nystrom.h"
 
 namespace shogun
 {
 
 namespace kernel_exp_family_impl
 {
-class Nystrom : public Full
+class Lite : public Nystrom
 {
 public :
-	Nystrom(SGMatrix<float64_t> data, SGMatrix<float64_t> basis,
+	Lite(SGMatrix<float64_t> data, SGMatrix<float64_t> basis,
 			std::shared_ptr<kernel::Base> kernel, float64_t lambda,
 			float64_t lambda_l2=0.0, bool init_base_and_data=true);
 
-	Nystrom(SGMatrix<float64_t> data, SGVector<index_t> basis_inds,
+	Lite(SGMatrix<float64_t> data, SGVector<index_t> basis_inds,
 			std::shared_ptr<kernel::Base> kernel, float64_t lambda,
 			float64_t lambda_l2=0.0, bool init_base_and_data=true);
 
-	Nystrom(SGMatrix<float64_t> data, index_t num_subsample_basis,
+	Lite(SGMatrix<float64_t> data, index_t num_subsample_basis,
 			std::shared_ptr<kernel::Base> kernel, float64_t lambda,
 			float64_t lambda_l2=0.0, bool init_base_and_data=true);
 
-	virtual ~Nystrom() {};
+	virtual ~Lite() {};
 
-	virtual void fit();
-
-	// modularisation of the fit method
-	virtual bool basis_is_subsampled_data() const { return m_basis_inds.vlen; }
 	virtual index_t get_system_size() const;
-	SGMatrix<float64_t> compute_system_matrix() const;
-	SGVector<float64_t> compute_system_vector() const;
 
 	virtual SGMatrix<float64_t> subsample_G_mm_from_G_mn(const SGMatrix<float64_t>& G_mn) const;
 	virtual bool can_subsample_G_mm_from_G_mn() const;
 	virtual SGMatrix<float64_t> compute_G_mn() const;
 	virtual SGMatrix<float64_t> compute_G_mm() const;
-	SGVector<float64_t> solve_system(const SGMatrix<float64_t>& system_matrix,
-			const SGVector<float64_t>& system_vector) const;
+	virtual SGVector<float64_t> compute_h() const;
 
-	// overloading base class methods as no-ops to get rid of xi parts
-	virtual void log_pdf_xi_add(index_t basis_ind, index_t idx_test, float64_t& xi) const {};
-	virtual void log_pdf_xi_result(float64_t xi, float64_t& result) const {};
-	virtual void grad_xi_add(index_t basis_ind, index_t idx_test,
-			SGVector<float64_t>& xi_grad) const {};
-	virtual void grad_xi_result(const SGVector<float64_t>& xi,
-			 SGVector<float64_t>& result) const {};
-	virtual void hessian_xi_add(index_t basis_ind, index_t idx_test,
-			SGMatrix<float64_t>& xi_hessian) const {};
-	virtual void hessian_xi_result(const SGMatrix<float64_t>& xi_hessian,
-			 SGMatrix<float64_t>& result) const {};
-	virtual void hessian_diag_xi_add(index_t basis_ind, index_t idx_test,
-			SGVector<float64_t>& xi_hessian_diag) const {};
-	virtual void hessian_diag_xi_result(const SGVector<float64_t>& xi_hessian_diag,
-			SGVector<float64_t>& result) const {};
-
-
-	// TODO these should go to the lib
-	static SGMatrix<float64_t> pinv_self_adjoint(const SGMatrix<float64_t>& A);
-	static SGVector<index_t> choose_m_in_n(index_t m, index_t n, bool sorted=true);
-	template <class T>
-	static SGMatrix<T> subsample_matrix_cols(const SGVector<index_t>& col_inds,
-			const SGMatrix<T>& mat)
-	{
-		auto D = mat.num_rows;
-		auto N_new = col_inds.vlen;
-		auto subsampled=SGMatrix<T>(D, N_new);
-		for (auto i=0; i<N_new; i++)
-		{
-			memcpy(subsampled.get_column_vector(i), mat.get_column_vector(col_inds[i]),
-					sizeof(T)*D);
-		}
-
-		return subsampled;
-	}
 protected:
 
 	float64_t m_lambda_l2;
@@ -121,4 +80,4 @@ protected:
 };
 
 }
-#endif // KERNEL_EXP_FAMILY_IMPL_NYSTROM__
+#endif // KERNEL_EXP_FAMILY_IMPL_LITE__

--- a/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
@@ -98,6 +98,16 @@ Nystrom::Nystrom(SGMatrix<float64_t> data, index_t num_subsample_basis,
 	m_lambda_l2 = lambda_l2;
 }
 
+SGMatrix<float64_t> Nystrom::get_basis() const
+{
+	return m_basis;
+}
+SGVector<index_t> Nystrom::get_basis_inds() const
+{
+	return m_basis_inds;
+}
+
+
 index_t Nystrom::get_system_size() const
 {
 	auto m = get_num_basis();

--- a/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
@@ -124,6 +124,11 @@ SGMatrix<float64_t> Nystrom::subsample_G_mm_from_G_mn(const SGMatrix<float64_t>&
 	return G_mm;
 }
 
+bool Nystrom::can_subsample_G_mm_from_G_mn() const
+{
+	return basis_is_subsampled_data();
+}
+
 SGMatrix<float64_t> Nystrom::compute_G_mn() const
 {
 	auto G_mn = m_kernel->dx_dy_all();
@@ -215,7 +220,7 @@ SGMatrix<float64_t> Nystrom::compute_system_matrix() const
 	if (m_lambda>0)
 	{
 		SGMatrix<float64_t> G_mm;
-		if (basis_is_subsampled_data())
+		if (can_subsample_G_mm_from_G_mn())
 		{
 			SG_SINFO("Sub-sampling kernel Hessians for basis.\n");
 			G_mm = subsample_G_mm_from_G_mn(G_mn);

--- a/src/shogun/distributions/kernel_exp_family/impl/Nystrom.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/Nystrom.h
@@ -65,6 +65,9 @@ public :
 
 	virtual void fit();
 
+	virtual SGMatrix<float64_t> get_basis() const;
+	virtual SGVector<index_t> get_basis_inds() const;
+
 	// modularisation of the fit method
 	virtual bool basis_is_subsampled_data() const { return m_basis_inds.vlen; }
 	virtual index_t get_system_size() const;

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
@@ -63,6 +63,7 @@ public :
 	index_t get_num_dimensions() const;
 	index_t get_num_lhs() const;
 	index_t get_num_rhs() const;
+	bool is_symmetric() const;
 
 	virtual float64_t kernel(index_t idx_a, index_t idx_b) const=0;
 	virtual SGMatrix<float64_t> kernel_all() const;

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
@@ -65,17 +65,27 @@ public :
 	index_t get_num_rhs() const;
 
 	virtual float64_t kernel(index_t idx_a, index_t idx_b) const=0;
+	virtual SGMatrix<float64_t> kernel_all() const;
+
 	virtual SGMatrix<float64_t> dx_dy_dy(index_t idx_a, index_t idx_b) const=0;
 	virtual float64_t dx_dx_dy_dy_sum(index_t idx_a, index_t idx_b) const=0;
+
 	virtual SGMatrix<float64_t> dx_dy(index_t idx_a, index_t idx_b) const=0;
-	virtual SGMatrix<float64_t> dx_dy_all() const=0;
+	virtual SGMatrix<float64_t> dx_dy_all() const;
 
 	virtual SGVector<float64_t> dx(index_t a, index_t idx_b) const=0;
+	virtual SGMatrix<float64_t> dx_all() const;
+
+	virtual SGVector<float64_t> dy(index_t a, index_t idx_b) const=0;
+	virtual SGMatrix<float64_t> dy_all() const;
+
 	virtual SGVector<float64_t> dx_dx(index_t a, index_t idx_b) const=0;
 	virtual SGMatrix<float64_t> dx_i_dx_i_dx_j(index_t a, index_t idx_b) const=0;
 	virtual SGMatrix<float64_t> dx_i_dx_j(index_t a, index_t idx_b) const=0;
 	virtual SGMatrix<float64_t> dx_i_dx_j_dx_k_dot_vec(index_t idx_a, index_t idx_b, const SGVector<float64_t>& vec) const=0;
 	virtual SGMatrix<float64_t> dx_i_dx_j_dx_k_dx_k_row_sum(index_t idx_a, index_t idx_b) const=0;
+
+	virtual SGVector<float64_t> dy_dy(index_t a, index_t idx_b) const=0;
 
 	// old develop code
 	virtual SGMatrix<float64_t> dx_dx_dy_dy(index_t idx_a, index_t idx_b) const=0;

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Gaussian.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Gaussian.h
@@ -64,9 +64,10 @@ public :
 	virtual SGMatrix<float64_t> dx_dy_dy(index_t idx_a, index_t idx_b) const;
 	virtual float64_t dx_dx_dy_dy_sum(index_t idx_a, index_t idx_b) const;
 	virtual SGMatrix<float64_t> dx_dy(index_t idx_a, index_t idx_b) const;
-	virtual SGMatrix<float64_t> dx_dy_all() const;
 	virtual SGVector<float64_t> dx(index_t a, index_t idx_b) const;
+	virtual SGVector<float64_t> dy(index_t a, index_t idx_b) const;
 	virtual SGVector<float64_t> dx_dx(index_t a, index_t idx_b) const;
+	virtual SGVector<float64_t> dy_dy(index_t a, index_t idx_b) const;
 	virtual SGMatrix<float64_t> dx_i_dx_i_dx_j(index_t a, index_t idx_b) const;
 	virtual SGMatrix<float64_t> dx_i_dx_j(index_t a, index_t idx_b) const;
 	virtual SGMatrix<float64_t> dx_dx_dy_dy(index_t idx_a, index_t idx_b) const;


### PR DESCRIPTION
I wanted to have the nystromified-lite, i.e. allowing a subset as a basis, for a figure for the poster. My first attempt at a quick hacked implementation using autograd was incredibly slow and also clearly wrong, so I did it the right way instead. :)

Seems to work reasonably well on a toy problem, but haven't implemented any tests.