### PR TITLE
some fixes to kexpfams

### DIFF
--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
@@ -138,3 +138,22 @@ float64_t Lite::log_pdf(index_t idx_test) const
 	}
 	return beta_sum;
 }
+
+// TODO: implement these...
+SGVector<float64_t> Lite::grad(index_t idx_test) const
+{
+	SG_SERROR("Lite::grad not implemented yet");
+	return SGVector<float64_t>();
+}
+
+SGMatrix<float64_t> Lite::hessian(index_t idx_test) const
+{
+	SG_SERROR("Lite::hessian not implemented yet");
+	return SGMatrix<float64_t>();
+}
+
+SGVector<float64_t> Lite::hessian_diag(index_t idx_test) const
+{
+	SG_SERROR("Lite::hessian_diag not implemented yet");
+	return SGVector<float64_t>();
+}

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.cpp
@@ -69,8 +69,6 @@ index_t Lite::get_system_size() const
 
 SGMatrix<float64_t> Lite::subsample_G_mm_from_G_mn(const SGMatrix<float64_t>& G_mn) const
 {
-	// TODO: would be better to make this a compile-time error
-	// like https://stackoverflow.com/a/24610165/344821
 	SG_SERROR("Can't subsample G_mm from G_mn for Lite");
 
 	SGMatrix<float64_t> return_something(0, 0);
@@ -95,7 +93,7 @@ SGMatrix<float64_t> Lite::compute_G_mm() const
 
 	auto kernel=m_kernel->shallow_copy();
 	kernel->set_lhs(basis);
-	kernel->set_rhs(basis);
+	kernel->set_rhs();  // make symmetric
 	kernel->precompute();
 
 	auto G_mm = kernel->kernel_all();

--- a/src/shogun/distributions/kernel_exp_family/impl/Lite.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/Lite.h
@@ -73,6 +73,9 @@ public :
 	virtual SGVector<float64_t> compute_h() const;
 
 	virtual float64_t log_pdf(index_t idx_test) const;
+	virtual SGVector<float64_t> grad(index_t idx_test) const;
+	virtual SGMatrix<float64_t> hessian(index_t idx_test) const;
+	virtual SGVector<float64_t> hessian_diag(index_t idx_test) const;
 
 protected:
 

--- a/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/Nystrom.cpp
@@ -152,7 +152,7 @@ SGMatrix<float64_t> Nystrom::compute_G_mm() const
 
 	auto kernel=m_kernel->shallow_copy();
 	kernel->set_lhs(basis);
-	kernel->set_rhs(basis);
+	kernel->set_rhs();  // make symmetric
 	kernel->precompute();
 	auto G_mm = kernel->dx_dy_all();
 

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.cpp
@@ -61,6 +61,11 @@ void Base::set_rhs(SGVector<float64_t> rhs)
 	set_rhs(SGMatrix<float64_t>(rhs));
 }
 
+void Base::set_rhs()
+{
+    set_rhs(SGMatrix<float64_t>());
+}
+
 void Base::set_lhs(SGMatrix<float64_t> lhs)
 {
 	m_lhs = lhs;
@@ -73,7 +78,7 @@ void Base::set_lhs(SGVector<float64_t> lhs)
 
 index_t Base::get_num_rhs() const
 {
-	return m_rhs.num_cols;
+	return is_symmetric() ? m_lhs.num_cols : m_rhs.num_cols;
 }
 
 bool Base::is_symmetric() const

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.cpp
@@ -135,6 +135,14 @@ SGMatrix<float64_t> Base::dx_all() const
     return result;
 }
 
+float64_t Base::sum_dy_dy(index_t idx_a, index_t idx_b) const
+{
+    auto D = get_num_dimensions();
+    SGVector<float64_t> full = dy_dy(idx_a, idx_b);
+    Map<VectorXd> eigen_full(full.vector, D);
+    return eigen_full.sum();
+}
+
 SGMatrix<float64_t> Base::dy_all() const
 {
     auto D = get_num_dimensions();

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
@@ -58,6 +58,7 @@ public :
 
 	virtual void set_rhs(SGMatrix<float64_t> rhs);
 	virtual void set_rhs(SGVector<float64_t> rhs);
+	virtual void set_rhs(); // to make it symmetric
 	virtual void set_lhs(SGMatrix<float64_t> lhs);
 	virtual void set_lhs(SGVector<float64_t> lhs);
 	index_t get_num_dimensions() const;

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Base.h
@@ -88,6 +88,7 @@ public :
 	virtual SGMatrix<float64_t> dx_i_dx_j_dx_k_dx_k_row_sum(index_t idx_a, index_t idx_b) const=0;
 
 	virtual SGVector<float64_t> dy_dy(index_t a, index_t idx_b) const=0;
+	virtual float64_t sum_dy_dy(index_t a, index_t idx_b) const;
 
 	// old develop code
 	virtual SGMatrix<float64_t> dx_dx_dy_dy(index_t idx_a, index_t idx_b) const=0;

--- a/src/shogun/distributions/kernel_exp_family/impl/kernel/Gaussian.cpp
+++ b/src/shogun/distributions/kernel_exp_family/impl/kernel/Gaussian.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<shogun::kernel_exp_family_impl::kernel::Base> Gaussian::shallow_
 
 float64_t Gaussian::kernel(index_t idx_a, index_t idx_b) const
 {
-	return CMath::exp(-sq_difference_norm(idx_a, idx_b) / m_sigma);
+	return std::exp(-sq_difference_norm(idx_a, idx_b) / m_sigma);
 }
 
 float64_t Gaussian::sq_difference_norm(index_t idx_a,  index_t idx_b) const


### PR DESCRIPTION
Think `Lite::compute_h` was slightly wrong before; also fix a bug + make kernels actually able to use their symmetry.